### PR TITLE
Fixing Typescript dependency issue

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "react-datepicker": "^6.2.0",
         "react-dom": "^18.2.0",
         "react-google-autocomplete": "^2.7.3",
-        "react-router-dom": "^6.22.1",
+        "react-router-dom": "^6.22.2",
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.8",
         "viem": "^2.7.15",
@@ -5614,9 +5614,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.1.tgz",
-      "integrity": "sha512-zcU0gM3z+3iqj8UX45AmWY810l3oUmXM7uH4dt5xtzvMhRtYVhKGOmgOd1877dOPPepfCjUv57w+syamWIYe7w==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.2.tgz",
+      "integrity": "sha512-+Rnav+CaoTE5QJc4Jcwh5toUpnVLKYbpU6Ys0zqbakqbaLQHeglLVHPfxOiQqdNmUy5C2lXz5dwC6tQNX2JW2Q==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -21372,11 +21372,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.22.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.1.tgz",
-      "integrity": "sha512-0pdoRGwLtemnJqn1K0XHUbnKiX0S4X8CgvVVmHGOWmofESj31msHo/1YiqcJWK7Wxfq2a4uvvtS01KAQyWK/CQ==",
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.2.tgz",
+      "integrity": "sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==",
       "dependencies": {
-        "@remix-run/router": "1.15.1"
+        "@remix-run/router": "1.15.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -21386,12 +21386,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.22.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.1.tgz",
-      "integrity": "sha512-iwMyyyrbL7zkKY7MRjOVRy+TMnS/OPusaFVxM2P11x9dzSzGmLsebkCvYirGq0DWB9K9hOspHYYtDz33gE5Duw==",
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.2.tgz",
+      "integrity": "sha512-WgqxD2qySEIBPZ3w0sHH+PUAiamDeszls9tzqMPBDA1YYVucTBXLU7+gtRfcSnhe92A3glPnvSxK2dhNoAVOIQ==",
       "dependencies": {
-        "@remix-run/router": "1.15.1",
-        "react-router": "6.22.1"
+        "@remix-run/router": "1.15.2",
+        "react-router": "6.22.2"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,12 +20,15 @@
     "react-datepicker": "^6.2.0",
     "react-dom": "^18.2.0",
     "react-google-autocomplete": "^2.7.3",
-    "react-router-dom": "^6.22.1",
+    "react-router-dom": "^6.22.2",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.8",
     "viem": "^2.7.15",
     "wagmi": "^2.5.7",
     "web-vitals": "^2.1.4"
+  },
+  "overrides": {
+    "typscript": "^5.0.4"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Updating deps, adds typescript override

`react-scripts` requires TypeScript 3 or 4; `wagmi` requires TypeScript 5.  Instead of changing libraries, we're forcing `react-scripts` to deal with it and we'll ignore the errors. 🤣  

Suggested Process:

- [ ] Delete `node_modules`
- [ ] Run `npm install --legacy-peer-deps `
- [ ] Run `npm start` 